### PR TITLE
Feature/add adult events option

### DIFF
--- a/checkout_settings.go
+++ b/checkout_settings.go
@@ -182,7 +182,7 @@ func (c *Client) CheckoutCreate(ctx context.Context, req *CheckoutCreateRequest)
 func (c *Client) CheckoutGet(ctx context.Context, id string) (*Checkout, error) {
 	s := new(Checkout)
 
-	return s, c.getJSON(ctx, fmt.Sprintf("/checkout_settings/%d/", id), nil, s)
+	return s, c.getJSON(ctx, fmt.Sprintf("/checkout_settings/%s/", id), nil, s)
 }
 
 // CheckoutByEvent gets and returns a list of checkout_settings associated with a given event by its event_id

--- a/event.go
+++ b/event.go
@@ -678,7 +678,7 @@ func (c *Client) EventDeleteTicketClass(ctx context.Context, eventId, ticketId s
 func (c *Client) EventGetCannedQuestions(ctx context.Context, id string, q *EventGetCannedQuestions) (interface{}, error) {
 	var result interface{}
 
-	return result, c.getJSON(ctx, fmt.Sprintf("/events/%d/canned_questions/", id), q, result)
+	return result, c.getJSON(ctx, fmt.Sprintf("/events/%s/canned_questions/", id), q, result)
 }
 
 // EventCreateCannedQuestion creates a new canned question; returns the result as a question
@@ -687,7 +687,7 @@ func (c *Client) EventGetCannedQuestions(ctx context.Context, id string, q *Even
 func (c *Client) EventCreateCannedQuestion(ctx context.Context, id string, q *EventCreateCannedQuestion) (interface{}, error) {
 	var result interface{}
 
-	return result, c.postJSON(ctx, fmt.Sprintf("/events/%d/canned_questions/", id), q, result)
+	return result, c.postJSON(ctx, fmt.Sprintf("/events/%s/canned_questions/", id), q, result)
 }
 
 // Eventbrite allows event organizers to add custom questions that attendees fill out upon registration.

--- a/event.go
+++ b/event.go
@@ -119,6 +119,8 @@ type EventSearchRequest struct {
 	IncludeAllSeriesInstances bool `json:"include_all_series_instances"`
 	// Boolean for whether or not you want to see events without tickets on sale.
 	IncludeUnavailableEvents bool `json:"include_unavailable_events"`
+	// Boolean for whether or not you want to see adult events
+	IncludeAdultEvents bool `json:"include_adult_events"`
 	// Incorporate additional information from the user’s historic preferences.
 	IncorporateUserAffinities bool `json:"incorporate_user_affinities"`
 	// Make search results prefer events in these categories. This should be a comma delimited string of category IDs.


### PR DESCRIPTION
Per https://www.eventbrite.com/developer/v3/endpoints/events/#ebapi-parameters I've added the include_adult_events option so that I can explicitly allow or deny adult events from returning in the search results.